### PR TITLE
Support older MacOS processor

### DIFF
--- a/lib/jekyll-tailwind/installer.rb
+++ b/lib/jekyll-tailwind/installer.rb
@@ -11,6 +11,8 @@ module Jekyll
         case RUBY_PLATFORM
         when "arm64-darwin23"
           "macos-arm64"
+        when "x86_64-darwin"
+          "macos-x64"
         when "x86_64-linux"
           "linux-x64"
         else

--- a/lib/jekyll-tailwind/installer.rb
+++ b/lib/jekyll-tailwind/installer.rb
@@ -11,7 +11,7 @@ module Jekyll
         case RUBY_PLATFORM
         when "arm64-darwin23"
           "macos-arm64"
-        when "x86_64-darwin"
+        when "x86_64-darwin23"
           "macos-x64"
         when "x86_64-linux"
           "linux-x64"

--- a/lib/jekyll-tailwind/installer.rb
+++ b/lib/jekyll-tailwind/installer.rb
@@ -9,9 +9,9 @@ module Jekyll
     def initialize(options)
       @target =
         case RUBY_PLATFORM
-        when "arm64-darwin23"
+        when /^arm64-darwin/
           "macos-arm64"
-        when "x86_64-darwin23"
+        when /^x86_64-darwin/
           "macos-x64"
         when "x86_64-linux"
           "linux-x64"


### PR DESCRIPTION
My friend couldn't get tailwind-cli to install with this gem -- so I decided to fix it! He had a `x86_64-darwin23` platform.

For older macOS versions on Intel processors, you might see something like:

```
"x86_64-darwin19" (macOS Catalina)
"x86_64-darwin18" (macOS Mojave)
"x86_64-darwin17" (macOS High Sierra)
"x86_64-darwin16" (macOS Sierra)
```

Same with ARM processors. So this is why, I changed everything to regexp matching to include older OSX versions. As a bonus, newer version of OSX should work as well.
