### PR TITLE
pass multiple input files to single --input flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Fixed
+- Correctly pass multiple input files through a single --input flag
+
 ## [2.0.0] - 2024-09-30
 ### New
 - Use tailwindcss-ruby gem as a wrapper for executable.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
     forwardable-extended (2.6.0)
     google-protobuf (3.25.3)
     google-protobuf (3.25.3-arm64-darwin)
+    google-protobuf (3.25.3-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -95,6 +96,8 @@ GEM
       rake (>= 13.0.0)
     sass-embedded (1.71.1-arm64-darwin)
       google-protobuf (~> 3.25)
+    sass-embedded (1.71.1-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     standard (1.35.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -109,6 +112,7 @@ GEM
       rubocop-performance (~> 1.20.2)
     tailwindcss-ruby (3.4.13)
     tailwindcss-ruby (3.4.13-arm64-darwin)
+    tailwindcss-ruby (3.4.13-x86_64-linux)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
@@ -117,6 +121,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   jekyll-tailwind!

--- a/lib/jekyll-tailwind.rb
+++ b/lib/jekyll-tailwind.rb
@@ -30,11 +30,8 @@ module Jekyll
                 "--config", @config,
               ]
 
-      @inputs.each do |input|
-        # There could be multiple input files or non at all.
-        command += ["--input", input]
-      end
-
+      # There could be multiple input files or non at all.
+      command += ["--input", @inputs.join(' ')]
       command += ["--minify"] if @minify
       command += ["--postcss", @postcss] if File.exist?(@postcss)
 

--- a/lib/jekyll-tailwind.rb
+++ b/lib/jekyll-tailwind.rb
@@ -31,7 +31,7 @@ module Jekyll
               ]
 
       # There could be multiple input files or non at all.
-      command += ["--input", @inputs.join(' ')]
+      command += ["--input", @inputs.join(' ')] unless @inputs.empty?
       command += ["--minify"] if @minify
       command += ["--postcss", @postcss] if File.exist?(@postcss)
 


### PR DESCRIPTION
solves #14 

multiple input files (let's say `test.css` and `test1.css`) currently passed to tailwindcss executable each through a separate --input flag.

Like this:
```
tailwindcss --input test.css --input test2.css --output out.css
```

But in this case, only last --input flag is being passed on and `test.css` will not be included in output file. 

It would be correct to pass multiple files to a single --input flag. Like so:

```
tailwindcss --input test.css test2.css --output out.css
```


I'm not sure if I got it 100% right. It would be sweet if anyone can confirm that this actually resolves the issue.